### PR TITLE
Added Hotkeys for Ignoring Armor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add login
 -   Add the ability to save builds
+-   Add about page with changelog
 
 ### Weapon Page
 
@@ -28,7 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add character preview
 -   Fix armor weight filtering (sometimes recommended armor sets will be 0.1 over the limit)
--   Add hotkeys to quickly ignore any item in the results table
+
+## [2.7.0] - 2025-01-20
+
+### Added
+
+-   Added hotkeys to quickly ignore any item in the results table
 
 ## [2.6.0] - 2025-01-20
 

--- a/src/app/armor/components/ArmorResultRow.tsx
+++ b/src/app/armor/components/ArmorResultRow.tsx
@@ -4,6 +4,7 @@ function ArmorResultRow(props: {
     armorId?: string;
     stats: string[];
     addIgnoredItem: Function;
+    hotkey?: string;
 }) {
     let ignoreButton;
     let name;
@@ -26,6 +27,8 @@ function ArmorResultRow(props: {
         ignoreButton = (
             <button
                 onClick={() => props.addIgnoredItem(props.armorId)}
+                // add hint on hover
+                title={"Ignore this armor (CTRL+i+" + props.hotkey + ")"}
                 style={{
                     marginLeft: "5px",
                     backgroundColor: "transparent",

--- a/src/app/armor/components/ArmorResultSet.tsx
+++ b/src/app/armor/components/ArmorResultSet.tsx
@@ -7,6 +7,7 @@ function ArmorResultSet(props: {
     itemStats: string[][];
     setStats: string[];
     addIgnoredItem: Function[];
+    hotkeys: string[];
 }) {
     return (
         <>
@@ -33,6 +34,7 @@ function ArmorResultSet(props: {
                     armorId={props.armorIds[0]}
                     stats={props.itemStats[0]}
                     addIgnoredItem={props.addIgnoredItem[0]}
+                    hotkey={props.hotkeys[0]}
                 />
                 <ArmorResultRow
                     name={props.armorNames[1]}
@@ -40,6 +42,7 @@ function ArmorResultSet(props: {
                     armorId={props.armorIds[1]}
                     stats={props.itemStats[1]}
                     addIgnoredItem={props.addIgnoredItem[1]}
+                    hotkey={props.hotkeys[1]}
                 />
                 <ArmorResultRow
                     name={props.armorNames[2]}
@@ -47,6 +50,7 @@ function ArmorResultSet(props: {
                     armorId={props.armorIds[2]}
                     stats={props.itemStats[2]}
                     addIgnoredItem={props.addIgnoredItem[2]}
+                    hotkey={props.hotkeys[2]}
                 />
                 <ArmorResultRow
                     name={props.armorNames[3]}
@@ -54,6 +58,7 @@ function ArmorResultSet(props: {
                     armorId={props.armorIds[3]}
                     stats={props.itemStats[3]}
                     addIgnoredItem={props.addIgnoredItem[3]}
+                    hotkey={props.hotkeys[3]}
                 />
             </tbody>
         </>

--- a/src/app/armor/page.tsx
+++ b/src/app/armor/page.tsx
@@ -41,6 +41,13 @@ export default function ArmorPage() {
     const [chestpieces, setChestpieces] = useState(Array<Armor>());
     const [gauntlets, setGauntlets] = useState(Array<Armor>());
     const [leggings, setLeggings] = useState(Array<Armor>());
+    const [pressedKeys, setPressedKeys] = useState(new Set());
+
+    const hotkeyGroups = [
+        ["`", "1", "2", "3"],
+        ["4", "5", "6", "7"],
+        ["8", "9", "0", "-"],
+    ];
 
     // STATE UPDATE FUNCTIONS
     function updateLockedItems(itemType: string, newItem: Armor): void {
@@ -81,7 +88,7 @@ export default function ArmorPage() {
         setIgnoredItems([...ignoredItems.filter((i) => i !== oldItem)]);
     }
 
-    // CALLBACKS
+    // HELPER FUNCTIONS
     const ignoreAll = (): void => {
         // filter out No Helmet, No Chestpiece, No Gauntlets, No Leggings
         var completeList = [
@@ -97,9 +104,65 @@ export default function ArmorPage() {
         setIgnoredItems([]);
     };
 
+    const handleKeyDown = (event: KeyboardEvent): void => {
+        event.preventDefault();
+        setPressedKeys((prevKeys) => new Set(prevKeys).add(event.key));
+
+        if (pressedKeys.has("Control") && pressedKeys.has("i")) {
+            switch (event.key) {
+                case hotkeyGroups[0][0]:
+                    addIgnoredItem(best[0].helmet!);
+                    break;
+                case hotkeyGroups[0][1]:
+                    addIgnoredItem(best[0].chestpiece!);
+                    break;
+                case hotkeyGroups[0][2]:
+                    addIgnoredItem(best[0].gauntlets!);
+                    break;
+                case hotkeyGroups[0][3]:
+                    addIgnoredItem(best[0].leggings!);
+                    break;
+                case hotkeyGroups[1][0]:
+                    addIgnoredItem(best[1].helmet!);
+                    break;
+                case hotkeyGroups[1][1]:
+                    addIgnoredItem(best[1].chestpiece!);
+                    break;
+                case hotkeyGroups[1][2]:
+                    addIgnoredItem(best[1].gauntlets!);
+                    break;
+                case hotkeyGroups[1][3]:
+                    addIgnoredItem(best[1].leggings!);
+                    break;
+                case hotkeyGroups[2][0]:
+                    addIgnoredItem(best[2].helmet!);
+                    break;
+                case hotkeyGroups[2][1]:
+                    addIgnoredItem(best[2].chestpiece!);
+                    break;
+                case hotkeyGroups[2][2]:
+                    addIgnoredItem(best[2].gauntlets!);
+                    break;
+                case hotkeyGroups[2][3]:
+                    addIgnoredItem(best[2].leggings!);
+                    break;
+                default:
+                    break;
+            }
+        }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent): void => {
+        setPressedKeys((prevKeys) => {
+            const newKeys = new Set(prevKeys);
+            newKeys.delete(event.key);
+            return newKeys;
+        });
+    };
+
     // EFFECTS
-    // Load data from localStorage on component mount
     useEffect(() => {
+        // Load data from localStorage on component mount
         const localMaxEquipLoad = localStorage.getItem("localMaxEquipLoad");
         if (localMaxEquipLoad) {
             setMaxEquipLoad(JSON.parse(localMaxEquipLoad));
@@ -132,6 +195,17 @@ export default function ArmorPage() {
             setIgnoredItems(JSON.parse(localIgnoredItems));
         }
     }, []);
+
+    useEffect(() => {
+        // Add event listeners for hotkeys
+        document.addEventListener("keydown", handleKeyDown);
+        document.addEventListener("keyup", handleKeyUp);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener("keyup", handleKeyUp);
+        };
+    }, [pressedKeys]);
 
     useEffect(() => {
         localStorage.setItem("localMaxEquipLoad", JSON.stringify(maxEquipLoad));
@@ -560,12 +634,34 @@ export default function ArmorPage() {
                                                         set.leggings!
                                                     ),
                                             ]}
+                                            hotkeys={hotkeyGroups[i]}
                                         />
                                     );
                                 })}
                             </table>
                         </div>
                     </article>
+                    <div>
+                        <h2 style={{ textAlign: "center" }}>Ignoring Armor</h2>
+                        <p>
+                            Click the red "X" next to any armor piece to remove
+                            it from the pool of armor being considered for
+                            optimization. Some reasons you might do this
+                            include:
+                        </p>
+                        <ul>
+                            <li>You don't currently have the armor.</li>
+                            <li>You don't like the way the armor looks.</li>
+                            <li>You don't like the armor's stats.</li>
+                        </ul>
+                        <p>
+                            Alternatively, each armor piece has a hotkey
+                            associated with ignoring it. The hotkeys are the
+                            keys on the top row of your QWERTY keyboard, from
+                            backtick (`) to hyphen (-). Hover over any of the
+                            red "X"s to see what its hotkey is.
+                        </p>
+                    </div>
                 </div>
             </main>
         </div>

--- a/src/app/armor/page.tsx
+++ b/src/app/armor/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
     ARMOR_RESULTS_SET_IDS,
     CHESTPIECES,
@@ -43,11 +43,14 @@ export default function ArmorPage() {
     const [leggings, setLeggings] = useState(Array<Armor>());
     const [pressedKeys, setPressedKeys] = useState(new Set());
 
-    const hotkeyGroups = [
-        ["`", "1", "2", "3"],
-        ["4", "5", "6", "7"],
-        ["8", "9", "0", "-"],
-    ];
+    const hotkeyGroups = useMemo(
+        () => [
+            ["`", "1", "2", "3"],
+            ["4", "5", "6", "7"],
+            ["8", "9", "0", "-"],
+        ],
+        []
+    );
 
     // STATE UPDATE FUNCTIONS
     function updateLockedItems(itemType: string, newItem: Armor): void {
@@ -75,15 +78,6 @@ export default function ArmorPage() {
         setBreakpoint(value);
     }
 
-    function updateSortBy(value: string): void {
-        setSortBy(value);
-    }
-
-    function addIgnoredItem(newItem: Armor): void {
-        if (ignoredItems.includes(newItem)) return;
-        setIgnoredItems([...ignoredItems, newItem]);
-    }
-
     function removeIgnoredItem(oldItem: Armor): void {
         setIgnoredItems([...ignoredItems.filter((i) => i !== oldItem)]);
     }
@@ -104,61 +98,77 @@ export default function ArmorPage() {
         setIgnoredItems([]);
     };
 
-    const handleKeyDown = (event: KeyboardEvent): void => {
-        event.preventDefault();
-        setPressedKeys((prevKeys) => new Set(prevKeys).add(event.key));
+    // CALLBACKS
+    const addIgnoredItem = useCallback(
+        (newItem: Armor): void => {
+            if (ignoredItems.includes(newItem)) return;
+            setIgnoredItems([...ignoredItems, newItem]);
+        },
+        [ignoredItems]
+    );
 
-        if (pressedKeys.has("Control") && pressedKeys.has("i")) {
-            switch (event.key) {
-                case hotkeyGroups[0][0]:
-                    addIgnoredItem(best[0].helmet!);
-                    break;
-                case hotkeyGroups[0][1]:
-                    addIgnoredItem(best[0].chestpiece!);
-                    break;
-                case hotkeyGroups[0][2]:
-                    addIgnoredItem(best[0].gauntlets!);
-                    break;
-                case hotkeyGroups[0][3]:
-                    addIgnoredItem(best[0].leggings!);
-                    break;
-                case hotkeyGroups[1][0]:
-                    addIgnoredItem(best[1].helmet!);
-                    break;
-                case hotkeyGroups[1][1]:
-                    addIgnoredItem(best[1].chestpiece!);
-                    break;
-                case hotkeyGroups[1][2]:
-                    addIgnoredItem(best[1].gauntlets!);
-                    break;
-                case hotkeyGroups[1][3]:
-                    addIgnoredItem(best[1].leggings!);
-                    break;
-                case hotkeyGroups[2][0]:
-                    addIgnoredItem(best[2].helmet!);
-                    break;
-                case hotkeyGroups[2][1]:
-                    addIgnoredItem(best[2].chestpiece!);
-                    break;
-                case hotkeyGroups[2][2]:
-                    addIgnoredItem(best[2].gauntlets!);
-                    break;
-                case hotkeyGroups[2][3]:
-                    addIgnoredItem(best[2].leggings!);
-                    break;
-                default:
-                    break;
+    const updateSortBy = useCallback((value: string): void => {
+        setSortBy(value);
+    }, []);
+
+    const handleKeyDown = useCallback(
+        (event: KeyboardEvent): void => {
+            event.preventDefault();
+            setPressedKeys((prevKeys) => new Set(prevKeys).add(event.key));
+
+            if (pressedKeys.has("Control") && pressedKeys.has("i")) {
+                switch (event.key) {
+                    case hotkeyGroups[0][0]:
+                        addIgnoredItem(best[0].helmet!);
+                        break;
+                    case hotkeyGroups[0][1]:
+                        addIgnoredItem(best[0].chestpiece!);
+                        break;
+                    case hotkeyGroups[0][2]:
+                        addIgnoredItem(best[0].gauntlets!);
+                        break;
+                    case hotkeyGroups[0][3]:
+                        addIgnoredItem(best[0].leggings!);
+                        break;
+                    case hotkeyGroups[1][0]:
+                        addIgnoredItem(best[1].helmet!);
+                        break;
+                    case hotkeyGroups[1][1]:
+                        addIgnoredItem(best[1].chestpiece!);
+                        break;
+                    case hotkeyGroups[1][2]:
+                        addIgnoredItem(best[1].gauntlets!);
+                        break;
+                    case hotkeyGroups[1][3]:
+                        addIgnoredItem(best[1].leggings!);
+                        break;
+                    case hotkeyGroups[2][0]:
+                        addIgnoredItem(best[2].helmet!);
+                        break;
+                    case hotkeyGroups[2][1]:
+                        addIgnoredItem(best[2].chestpiece!);
+                        break;
+                    case hotkeyGroups[2][2]:
+                        addIgnoredItem(best[2].gauntlets!);
+                        break;
+                    case hotkeyGroups[2][3]:
+                        addIgnoredItem(best[2].leggings!);
+                        break;
+                    default:
+                        break;
+                }
             }
-        }
-    };
+        },
+        [addIgnoredItem, best, pressedKeys, hotkeyGroups]
+    );
 
-    const handleKeyUp = (event: KeyboardEvent): void => {
+    const handleKeyUp = useCallback((event: KeyboardEvent): void => {
         setPressedKeys((prevKeys) => {
             const newKeys = new Set(prevKeys);
             newKeys.delete(event.key);
             return newKeys;
         });
-    };
+    }, []);
 
     // EFFECTS
     useEffect(() => {
@@ -205,7 +215,7 @@ export default function ArmorPage() {
             document.removeEventListener("keydown", handleKeyDown);
             document.removeEventListener("keyup", handleKeyUp);
         };
-    }, [pressedKeys]);
+    }, [pressedKeys, handleKeyDown, handleKeyUp]);
 
     useEffect(() => {
         localStorage.setItem("localMaxEquipLoad", JSON.stringify(maxEquipLoad));
@@ -644,22 +654,24 @@ export default function ArmorPage() {
                     <div>
                         <h2 style={{ textAlign: "center" }}>Ignoring Armor</h2>
                         <p>
-                            Click the red "X" next to any armor piece to remove
-                            it from the pool of armor being considered for
-                            optimization. Some reasons you might do this
+                            Click the red &quot;X&quot; next to any armor piece
+                            to remove it from the pool of armor being considered
+                            for optimization. Some reasons you might do this
                             include:
                         </p>
                         <ul>
-                            <li>You don't currently have the armor.</li>
-                            <li>You don't like the way the armor looks.</li>
-                            <li>You don't like the armor's stats.</li>
+                            <li>You don&apos;t currently have the armor.</li>
+                            <li>
+                                You don&apos;t like the way the armor looks.
+                            </li>
+                            <li>You don&apos;t like the armor&apos;s stats.</li>
                         </ul>
                         <p>
                             Alternatively, each armor piece has a hotkey
                             associated with ignoring it. The hotkeys are the
                             keys on the top row of your QWERTY keyboard, from
                             backtick (`) to hyphen (-). Hover over any of the
-                            red "X"s to see what its hotkey is.
+                            red &quot;X&quot;s to see what its hotkey is.
                         </p>
                     </div>
                 </div>

--- a/src/app/armor/page.tsx
+++ b/src/app/armor/page.tsx
@@ -572,9 +572,15 @@ export default function ArmorPage() {
                             </button>
                         </div>
                         <div>
-                            <ul id="ignored-items">
+                            <ul
+                                id="ignored-items"
+                                style={{ listStyle: "none" }}
+                            >
                                 {ignoredItems.map((item: Armor) => (
-                                    <li key={item.id}>
+                                    <li
+                                        key={item.id}
+                                        style={{ display: "flex" }}
+                                    >
                                         {item.name}
                                         <button
                                             onClick={() =>

--- a/src/app/class/page.tsx
+++ b/src/app/class/page.tsx
@@ -246,9 +246,12 @@ export default function ClassPage() {
                     </div>
                     <hr />
                     <div>
-                        <ul id="classes">
+                        <ul
+                            id="classes"
+                            style={{ listStyleType: "none", padding: 0 }}
+                        >
                             {sorted.map((cls: any) => (
-                                <li key={cls.id}>
+                                <li key={cls.id} style={{ display: "flex" }}>
                                     <span>{cls.name}</span>
                                     <aside>lvl. {cls.total}</aside>
                                 </li>
@@ -402,9 +405,12 @@ export default function ClassPage() {
                         <b>Talismans</b>
                     </div>
                     <div>
-                        <ul id="talismans">
+                        <ul
+                            id="talismans"
+                            style={{ listStyle: "none", padding: 0 }}
+                        >
                             {TALISMANS.map((item: Talisman) => (
-                                <li key={item.id}>
+                                <li key={item.id} style={{ display: "flex" }}>
                                     <div>
                                         <input
                                             name="talisman"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -318,14 +318,10 @@ select option {
 
 .app ul {
     width: 100%;
-    padding: 0;
     margin: 0;
-    list-style: none;
-    list-style-type: none;
 }
 
 .app li {
-    display: flex;
     justify-content: space-between;
     word-wrap: break-word;
 }


### PR DESCRIPTION
# Current State
The only way of ignoring armor is to click the ignore button. The button can move depending on the length of the armor's name, making ignoring multiple armors in a row inconsistent.

# Target State
There will be a hotkey for each armor piece currently displayed for ignoring that armor piece.