### PR TITLE
Fix Use of Keyboard in Armor Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Add character preview
 -   Fix armor weight filtering (sometimes recommended armor sets will be 0.1 over the limit)
 
+## [2.7.1] - 2025-01-23
+
+### Fixed
+
+-   Fixed keyboard use on armor page
+
 ## [2.7.0] - 2025-01-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "erdtree",
-    "version": "2.6.0",
+    "version": "2.7.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/armor/page.tsx
+++ b/src/app/armor/page.tsx
@@ -113,7 +113,6 @@ export default function ArmorPage() {
 
     const handleKeyDown = useCallback(
         (event: KeyboardEvent): void => {
-            event.preventDefault();
             setPressedKeys((prevKeys) => new Set(prevKeys).add(event.key));
 
             if (pressedKeys.has("Control") && pressedKeys.has("i")) {

--- a/src/app/armor/page.tsx
+++ b/src/app/armor/page.tsx
@@ -116,6 +116,7 @@ export default function ArmorPage() {
             setPressedKeys((prevKeys) => new Set(prevKeys).add(event.key));
 
             if (pressedKeys.has("Control") && pressedKeys.has("i")) {
+                event.preventDefault();
                 switch (event.key) {
                     case hotkeyGroups[0][0]:
                         addIgnoredItem(best[0].helmet!);


### PR DESCRIPTION
# Current State
The keyboard is unresponsive on the armor page. The user cannot type into the input boxes, CTRL+F to open the search box, etc. The only keyboard inputs that work are the shortcuts for ignoring armor pieces.

# Target State
All keyboard inputs work.