### PR TITLE
Add Weapon Ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add character preview
 
+## [2.8.0] - 2025-01-23
+
+### Added
+
+-   Added weapon ranking
+
 ## [2.7.2] - 2025-01-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "erdtree",
-    "version": "2.7.2",
+    "version": "2.8.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/weapons/components/WeaponResultRow.tsx
+++ b/src/app/weapons/components/WeaponResultRow.tsx
@@ -28,9 +28,11 @@ export function WeaponResultRow(props: {
         baseDmg: AttackPowerTypeMap<number>;
         scalingDmg: AttackPowerTypeMap<number>;
     }>;
+    rank: number;
 }) {
     return (
         <tr>
+            <td>{props.rank}</td>
             <td>
                 <a
                     target="_blank"

--- a/src/app/weapons/page.tsx
+++ b/src/app/weapons/page.tsx
@@ -843,6 +843,11 @@ export default function Weapons() {
                             <table>
                                 <thead>
                                     <tr>
+                                        <th>
+                                            <b style={{ userSelect: "none" }}>
+                                                Rank
+                                            </b>
+                                        </th>
                                         <th style={{ minWidth: "2rem" }}>
                                             <b style={{ userSelect: "none" }}>
                                                 Weapon

--- a/src/app/weapons/script.tsx
+++ b/src/app/weapons/script.tsx
@@ -739,13 +739,14 @@ export function mapResults(
     results: WeaponResult[],
     sortBy: SortBy
 ): JSX.Element[] {
-    return sortResults(results, sortBy).map((weaponResult) => (
+    return sortResults(results, sortBy).map((weaponResult, i) => (
         <WeaponResultRow
             key={weaponResult.weaponName.replaceAll(" ", "-")}
             weaponName={weaponResult.weaponName}
             attackRatings={weaponResult.attackRatings}
             max={weaponResult.max}
             arBreakdown={weaponResult.arBreakdown}
+            rank={i + 1}
         />
     ));
 }


### PR DESCRIPTION
# Current State
The weapons are displayed in order of sorting method, with no indication for relative position in the order.

# Target State
Users will now be able to see the order in which the weapons are ranked, indicated as a new Rank column. This will easily tell players which weapons are better than others when comparing weapons in particularly large ranking pools.