### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,8 @@
 name: Lighthouse CI
 
+permissions:
+    contents: read
+
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Camburgaler/haligtree/security/code-scanning/5](https://github.com/Camburgaler/haligtree/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow primarily involves reading repository contents and does not appear to require write access, we will set `contents: read` as the minimal permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
