### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/Camburgaler/haligtree/security/code-scanning/4](https://github.com/Camburgaler/haligtree/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow only requires read access to the repository contents (e.g., to check out the code), the minimal permissions of `contents: read` should suffice. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field at the top of the file. This will apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
